### PR TITLE
feat: Add Linux support for dotfiles installation

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -21,14 +21,14 @@ brew "mas"  # Mac App Store CLI
 brew "kubectl"
 brew "docker"
 
-# Applications via Homebrew Cask
-cask "orbstack"
-cask "warp"
-cask "visual-studio-code"
-cask "spotify"
-cask "notion"
-cask "discord"
-cask "tailscale"
+# Applications via Homebrew Cask (macOS seulement)
+cask "orbstack"              # Alternative Linux: Docker (installé par le script)
+cask "warp"                   # Alternative Linux: Terminal natif (GNOME, Konsole, etc.)
+cask "visual-studio-code"     # Installé via Snap sur Linux
+cask "spotify"                # Installé via Snap sur Linux
+cask "notion"                 # Alternative Linux: Version web ou client non-officiel
+cask "discord"                # Installé via Snap sur Linux
+cask "tailscale"              # Installé via le dépôt apt sur Linux
 
-# Applications du Mac App Store (nécessite mas)
-mas "WhatsApp", id: 310633997
+# Applications du Mac App Store (macOS seulement)
+mas "WhatsApp", id: 310633997  # Alternative Linux: Version web

--- a/README.md
+++ b/README.md
@@ -1,49 +1,50 @@
 # Mes dotfiles
 
-Contient les fichiers de configuration pour mon environnement de développement.
+Ce dépôt contient mes fichiers de configuration personnels (dotfiles) pour macOS et Linux (Debian/Ubuntu). Le script d'installation est conçu pour automatiser la mise en place de mon environnement de développement.
 
-## Installation (macOS)
+## Installation
 
-### 1. Installer Homebrew
-Homebrew est le gestionnaire de paquets de macOS.  
-Exécute cette commande dans ton terminal :
+Le script `install.sh` détecte automatiquement votre système d'exploitation (macOS ou Linux) et installe les logiciels et configurations appropriés.
 
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
+1.  **Cloner le dépôt**
+    ```bash
+    git clone https://github.com/thomasorgeval/dotfiles.git ~/dotfiles
+    cd ~/dotfiles
+    ```
 
-### 2. Cloner le dépôt et lancer l'installation
-```bash
-# Cloner le dépôt
-git clone git@github.com:thomasorgeval/dotfiles.git ~/dotfiles
-cd ~/dotfiles
-chmod +x install.sh
-./install.sh
-```
+2.  **Lancer le script d'installation**
+    Le script vous demandera votre mot de passe `sudo` pour installer les paquets système.
+    ```bash
+    chmod +x install.sh
+    ./install.sh
+    ```
+
+### Systèmes d'exploitation supportés
+*   **macOS**: Utilise [Homebrew](https://brew.sh/) pour l'installation des paquets.
+*   **Linux**: Testé sur Debian/Ubuntu. Utilise `apt` et `snap`.
 
 ## Mise à jour
-Si tu souhaites mettre à jour tes dotfiles, exécute les commandes suivantes :
+Pour mettre à jour les dotfiles et les paquets installés, il suffit de se placer dans le dossier et de ré-exécuter le script d'installation.
 
 ```bash
 cd ~/dotfiles
 git pull origin main
-brew bundle install --file=Brewfile
-stow .  # Re-créer les liens si nécessaire
-chmod 700 ~/.ssh
-chmod 600 ~/.ssh/config
-source ~/.zshrc # Recharger la configuration de Zsh
+./install.sh
 ```
 
 ## Vérification
-Pour vérifier que tout fonctionne correctement, tu peux exécuter les commandes suivantes :
+Après l'installation, redémarrez votre terminal et vérifiez que tout fonctionne :
 
 ```bash
 # Vérifier la version de Starship
 starship --version
+
 # Vérifier la version de Zsh
 zsh --version
-# Vérifier la config de Git
-which git
-git --version
+
+# Vérifier la version de Node.js (installé via NVM)
+node --version
+
+# Vérifier la configuration de Git
 git config --global --list
 ```

--- a/install.sh
+++ b/install.sh
@@ -3,90 +3,204 @@
 # Script d'installation complète des dotfiles et applications
 set -e
 
-echo "🚀 Installation complète de l'environnement de développement..."
+# --- Fonctions utilitaires ---
 
-# Vérifier si Homebrew est installé
-if ! command -v brew &> /dev/null; then
-    echo "📦 Installation de Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# Fonction pour détecter le système d'exploitation
+get_os() {
+    case "$(uname -s)" in
+        Darwin)
+            echo "darwin"
+            ;;
+        Linux)
+            echo "linux"
+            ;;
+        *)
+            echo "unsupported"
+            ;;
+    esac
+}
 
-    # Ajouter Homebrew au PATH pour cette session
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-fi
+# --- Fonctions d'installation par OS ---
 
-# Installer toutes les applications depuis le Brewfile
-if [ -f "Brewfile" ]; then
-    echo "📱 Installation des applications depuis Brewfile..."
-    brew bundle install --file=Brewfile
-else
-    echo "⚠️  Brewfile non trouvé, installation manuelle..."
-    brew install git stow starship zoxide zsh-autosuggestions zsh-syntax-highlighting nvm mas ripgrep fd jq
-    brew install --cask orbstack warp visual-studio-code spotify notion discord tailscale
-    mas install 310633997  # WhatsApp
-fi
+install_macos_packages() {
+    echo "📦 Installation des paquets pour macOS..."
 
-# Créer les liens symboliques
-echo "🔗 Création des liens symboliques..."
-stow .
-
-# Vérifier si le dossier .ssh existe et configurer les permissions
-if [ -d ~/.ssh ]; then
-    echo "🔐 Configuration des permissions SSH..."
-    chmod 700 ~/.ssh
-
-    if [ -f ~/.ssh/config ]; then
-        chmod 600 ~/.ssh/config
-        echo "✅ Permissions SSH configurées"
+    # Vérifier si Homebrew est installé
+    if ! command -v brew &> /dev/null; then
+        echo "-> Installation de Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        # Ajouter Homebrew au PATH pour cette session
+        eval "$(/opt/homebrew/bin/brew shellenv)"
     fi
-else
-    echo "⚠️  Le dossier .ssh n'existe pas encore"
-fi
 
-# Configuration de NVM et Node.js
-echo "🟢 Configuration de NVM et Node.js..."
-export NVM_DIR="$HOME/.nvm"
+    # Installer toutes les applications depuis le Brewfile
+    if [ -f "Brewfile" ]; then
+        echo "-> Installation des applications depuis Brewfile..."
+        brew bundle install --file=Brewfile
+    else
+        echo "⚠️  Brewfile non trouvé, installation manuelle..."
+        brew install git stow starship zoxide zsh-autosuggestions zsh-syntax-highlighting nvm mas ripgrep fd jq
+        brew install --cask orbstack warp visual-studio-code spotify notion discord tailscale
+        mas install 310633997  # WhatsApp
+    fi
+}
 
-# Créer le répertoire NVM s'il n'existe pas
-[ ! -d "$NVM_DIR" ] && mkdir -p "$NVM_DIR"
+install_linux_packages() {
+    echo "📦 Installation des paquets pour Linux (Debian/Ubuntu)..."
 
-# Charger NVM
-if [ -s "/opt/homebrew/opt/nvm/nvm.sh" ]; then
-    source "/opt/homebrew/opt/nvm/nvm.sh"
-    source "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
+    echo "-> Mise à jour des paquets existants..."
+    sudo apt-get update && sudo apt-get upgrade -y
+
+    echo "-> Installation des dépendances de base..."
+    sudo apt-get install -y git stow curl zsh build-essential
+
+    echo "-> Installation des outils en ligne de commande..."
+    sudo apt-get install -y ripgrep jq fd-find zsh-autosuggestions zsh-syntax-highlighting
+
+    # fd-find est souvent installé sous le nom 'fdfind', on crée un lien symbolique vers 'fd'
+    if ! command -v fd &> /dev/null && command -v fdfind &> /dev/null; then
+        echo "-> Création du lien symbolique pour fd (fdfind)..."
+        sudo ln -s $(which fdfind) /usr/local/bin/fd
+    fi
+
+    echo "-> Installation de Starship..."
+    curl -sS https://starship.rs/install.sh | sh -s -- -y
+
+    echo "-> Installation de Zoxide..."
+    curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash
+
+    echo "-> Installation des outils de développement..."
+    # Docker
+    echo "-> Installation de Docker..."
+    sudo apt-get install -y docker.io
+    sudo groupadd -f docker
+    sudo usermod -aG docker $USER
+    echo "ℹ️  Vous devrez peut-être vous déconnecter/reconnecter pour utiliser Docker sans sudo."
+
+    # Outils graphiques (via Snap)
+    echo "-> Installation des applications graphiques via Snap..."
+    sudo apt-get install -y snapd
+
+    # VS Code
+    echo "-> Installation de Visual Studio Code..."
+    sudo snap install --classic code
+
+    # Spotify
+    echo "-> Installation de Spotify..."
+    sudo snap install spotify
+
+    # Discord
+    echo "-> Installation de Discord..."
+    sudo snap install discord
+
+    # Tailscale
+    echo "-> Installation de Tailscale..."
+    curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/$(lsb_release -cs).noarmor.gpg | sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+    curl -fsSL https://pkgs.tailscale.com/stable/ubuntu/$(lsb_release -cs).tailscale-keyring.list | sudo tee /etc/apt/sources.list.d/tailscale.list
+    sudo apt-get update
+    sudo apt-get install tailscale -y
+
+    # Kubectl
+    echo "-> Installation de Kubectl..."
+    sudo snap install kubectl --classic
+
+    echo "---"
+    echo "⚠️  Applications non disponibles sur Linux via ce script :"
+    echo "  - OrbStack: Alternative -> Docker (installé)"
+    echo "  - Warp: Alternative -> Utilisez votre terminal Linux préféré (GNOME Terminal, Konsole, etc.)"
+    echo "  - Notion: Utilisez la version web ou des clients non officiels (ex: snap install notion-snap)."
+    echo "  - WhatsApp: Utilisez la version web."
+    echo "---"
+}
+
+# --- Script principal ---
+main() {
+    echo "🚀 Installation complète de l'environnement de développement..."
+
+    local os
+    os=$(get_os)
+
+    if [[ "$os" == "darwin" ]]; then
+        install_macos_packages
+    elif [[ "$os" == "linux" ]]; then
+        install_linux_packages
+    else
+        echo "❌ Système d'exploitation non supporté : $(uname -s)"
+        exit 1
+    fi
+
+    # --- Étapes communes après l'installation des paquets ---
+
+    # Créer les liens symboliques avec Stow
+    echo "🔗 Création des liens symboliques..."
+    stow .
+
+    # Configurer les permissions SSH
+    if [ -d ~/.ssh ]; then
+        echo "🔐 Configuration des permissions SSH..."
+        chmod 700 ~/.ssh
+        if [ -f ~/.ssh/config ]; then
+            chmod 600 ~/.ssh/config
+            echo "✅ Permissions SSH configurées."
+        fi
+    else
+        echo "⚠️  Le dossier .ssh n'existe pas encore."
+    fi
+
+    # --- Installation et configuration de NVM & Node.js ---
+    install_nvm_and_node
+
+    # --- Instructions finales ---
+    display_final_instructions "$os"
+
+    echo ""
+    echo "🎉 Installation terminée !"
+}
+
+# --- Fonction pour NVM & Node.js ---
+install_nvm_and_node() {
+    echo "🟢 Configuration de NVM et Node.js..."
+
+    # Installer NVM
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+
+    export NVM_DIR="$HOME/.nvm"
+    # shellcheck source=/dev/null
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
     # Installer et utiliser la version LTS de Node.js
-    echo "📦 Installation de Node.js LTS..."
+    echo "-> Installation de Node.js LTS..."
     nvm install --lts
     nvm use --lts
     nvm alias default node
 
-    echo "✅ Node.js $(node --version) installé et configuré"
-else
-    echo "⚠️  NVM non trouvé, redémarrez votre terminal et lancez 'nvm install --lts'"
-fi
+    echo "✅ Node.js $(node --version) installé et configuré."
+}
 
-# Recharger la configuration zsh
-if [ -f ~/.zshrc ]; then
-    echo "♻️  Rechargement de la configuration zsh..."
-    source ~/.zshrc 2>/dev/null || echo "ℹ️  Redémarrez votre terminal pour appliquer les changements"
-fi
+# --- Fonction pour afficher les instructions finales ---
+display_final_instructions() {
+    local os=$1
 
-echo ""
-echo "🎉 Installation terminée !"
-echo ""
-echo "📝 Prochaines étapes :"
-echo "  - Redémarrez votre terminal"
-echo "  - Connectez-vous au Mac App Store pour WhatsApp"
-echo "  - Vérifiez Node.js: node --version"
-echo "  - Vérifiez la config Git: git config --global --list"
-echo "  - Vérifiez la config SSH: ssh -T git@github.com"
-echo ""
-echo "🚀 Applications installées :"
-echo "  • OrbStack (Docker)"
-echo "  • Warp (Terminal)"
-echo "  • VS Code"
-echo "  • Spotify"
-echo "  • Notion"
-echo "  • Discord"
-echo "  • Tailscale"
-echo "  • WhatsApp"
+    echo ""
+    echo "📝 Prochaines étapes :"
+    echo "  - Redémarrez votre terminal pour que tous les changements prennent effet."
+    echo "  - Vérifiez Node.js : node --version"
+    echo "  - Vérifiez Git : git config --global --list"
+    echo "  - Vérifiez la connexion SSH à GitHub : ssh -T git@github.com"
+
+    if [[ "$os" == "darwin" ]]; then
+        echo "  - Connectez-vous au Mac App Store pour que 'mas' puisse gérer les applications."
+    fi
+
+    echo ""
+    echo "🚀 Applications installées :"
+    if [[ "$os" == "darwin" ]]; then
+        echo "  • OrbStack (Docker), Warp (Terminal), VS Code, Spotify, Notion, Discord, Tailscale, WhatsApp"
+    elif [[ "$os" == "linux" ]]; then
+        echo "  • Docker, VS Code, Spotify, Discord, Tailscale"
+        echo "  • Pour les autres, voir les alternatives mentionnées pendant l'installation."
+    fi
+}
+
+# Lancer le script principal
+main


### PR DESCRIPTION
This commit introduces support for Linux (Debian/Ubuntu-based distributions) to the dotfiles installation script, which was previously macOS-only.

The `install.sh` script has been refactored to:
- Automatically detect the operating system (macOS or Linux).
- Use modular functions for OS-specific package installations.
- Utilize `apt` and `snap` for installing packages and applications on Linux.
- Standardize the NVM installation process to use the official script, making it platform-independent.

The `README.md` has been updated with unified installation instructions for both operating systems, and the `Brewfile` has been commented to clarify which applications are macOS-specific and suggest Linux alternatives.